### PR TITLE
Add simple command-line calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # sridhar_Python
+
+Simple command-line calculator.
+
+## Usage
+
+```bash
+python calculator.py add 2 3
+```
+
+Available operations: `add`, `subtract`, `multiply`, and `divide`.
+

--- a/calculator.py
+++ b/calculator.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Simple command-line calculator."""
+
+import argparse
+
+
+def add(a: float, b: float) -> float:
+    """Return the sum of a and b."""
+    return a + b
+
+
+def subtract(a: float, b: float) -> float:
+    """Return the difference of a and b."""
+    return a - b
+
+
+def multiply(a: float, b: float) -> float:
+    """Return the product of a and b."""
+    return a * b
+
+
+def divide(a: float, b: float) -> float:
+    """Return the quotient of a and b.
+
+    Raises
+    ------
+    ValueError
+        If b is zero.
+    """
+    if b == 0:
+        raise ValueError("Cannot divide by zero.")
+    return a / b
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simple calculator.")
+    parser.add_argument("operation", choices=["add", "subtract", "multiply", "divide"], help="Operation to perform")
+    parser.add_argument("a", type=float, help="First operand")
+    parser.add_argument("b", type=float, help="Second operand")
+    args = parser.parse_args()
+
+    operations = {
+        "add": add,
+        "subtract": subtract,
+        "multiply": multiply,
+        "divide": divide,
+    }
+    result = operations[args.operation](args.a, args.b)
+    print(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a simple command-line calculator supporting add, subtract, multiply, and divide
- Document usage in README

## Testing
- `python calculator.py add 2 3`


------
https://chatgpt.com/codex/tasks/task_e_68c1599457ec832f86b6fb286db8fd84